### PR TITLE
relax upper bound on base to <5.0

### DIFF
--- a/data-carousel.cabal
+++ b/data-carousel.cabal
@@ -19,7 +19,7 @@ source-repository head
 
 library
   exposed-modules:     Data.Carousel
-  build-depends:       base >=4.7 && <4.8,
+  build-depends:       base >=4.7 && <5.0,
                        containers >=0.5.5.1,
                        lens >=4.5
   hs-source-dirs:      src


### PR DESCRIPTION
@jonsterling could you please also relax the upper bound on version 0.1.0.0 on Hackage?
